### PR TITLE
Use Text.rich rather than RichText

### DIFF
--- a/flutter_highlighting/lib/flutter_highlighting.dart
+++ b/flutter_highlighting/lib/flutter_highlighting.dart
@@ -90,8 +90,8 @@ class HighlightView extends StatelessWidget {
     return Container(
       color: theme[_rootKey]?.backgroundColor ?? _defaultBackgroundColor,
       padding: padding,
-      child: RichText(
-        text: TextSpan(
+      child: Text.rich(
+        TextSpan(
           style: _textStyle,
           children: _convert(
             highlight.highlight(languageId ?? '', source, true).nodes ?? [],


### PR DESCRIPTION
`Text.rich` handles selection and text scaling for you automatically.

Fixes #70 